### PR TITLE
Init new builder from credentials json.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,19 @@ impl<'a> GmailClientBuilder {
         })
     }
 
+    /// Create a new `GmailClientBuilder`.
+    /// Uses str representation of credentials JSON instead of a filepath.
+    pub fn new_from_string<S: AsRef<str>>(
+        service_account_json: S,
+        send_from_email: S,
+    ) -> Result<Self> {
+        Ok(Self {
+            service_account: ServiceAccount::load_from_string(service_account_json.as_ref())?,
+            send_from_email: send_from_email.as_ref().to_string(),
+            mock_mode: false,
+        })
+    }
+
     /// Set "mock mode" which, if set to true, will log print the email instead of sending it.
     pub fn mock_mode(mut self, enabled: bool) -> Self {
         self.mock_mode = enabled;

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -25,4 +25,8 @@ impl ServiceAccount {
             .map_err(|e| GoogleApiError::ServiceAccountLoadFailure(e))?;
         Ok(serde_json::from_str(&file_contents)?)
     }
+
+    pub fn load_from_string<S: AsRef<str>>(file_contents: S) -> Result<Self> {
+        Ok(serde_json::from_str(file_contents.as_ref())?)
+    }
 }


### PR DESCRIPTION
For cases where it would be preferable to read a credentials JSON in at compile time rather than run time.